### PR TITLE
Increase friction coefficient

### DIFF
--- a/models/aws_robomaker_warehouse_GroundB_01/model.sdf
+++ b/models/aws_robomaker_warehouse_GroundB_01/model.sdf
@@ -23,8 +23,8 @@
         <surface>
           <friction>
             <ode>
-              <mu>0.3</mu>
-              <mu2>0.3</mu2>
+              <mu>0.7</mu>
+              <mu2>0.7</mu2>
               <fdir1>0 0 0</fdir1>
               <slip1>0</slip1>
               <slip2>0</slip2>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Default friction of 0.3 causes robots like husky to slip significantly causing users to be confused. higher friction should reduce these issues. Sample application for testing husky in this world at https://github.com/aws-samples/multi-robot-fleet-sample-application/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
