### PR TITLE
Adding gazebo model path to stop requiring modification of gazebo mod…

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
-    <gazebo_ros plugin_path="${prefix}/lib" gazebo_media_path="${prefix}"/>
+    <gazebo_ros plugin_path="${prefix}/lib" gazebo_media_path="${prefix}" gazebo_model_path="${prefix}/models"/>
   </export>
 </package>


### PR DESCRIPTION
…el path env var

This now makes it so that you don't need to export gazebo model path variable. Just building the package is sufficient. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
