### PR TITLE
set gazebo_ros as a depend rather than exec_depend

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   
-  <exec_depend>gazebo_ros</exec_depend>
+  <depend>gazebo_ros</depend>
   <exec_depend>gazebo</exec_depend>
   <exec_depend>gazebo_plugins</exec_depend>
 


### PR DESCRIPTION
ROS Build farm environment does not have gazebo_ros available

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
