### PR TITLE
Fix launch files for using gazebo_ros

### DIFF
--- a/launch/no_roof_small_warehouse.launch.py
+++ b/launch/no_roof_small_warehouse.launch.py
@@ -16,59 +16,21 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 
-from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
-from launch.conditions import IfCondition
+import launch
+from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PythonExpression
-from launch_ros.actions import Node
 
 
 def generate_launch_description():
-	# Get the launch directory
-	aws_small_warehouse_dir = get_package_share_directory('aws_robomaker_small_warehouse_world')
-
-	# Launch configuration variables specific to simulation
-	use_sim_time = LaunchConfiguration('use_sim_time')
-	use_simulator = LaunchConfiguration('use_simulator')
-	headless = LaunchConfiguration('headless')
-	world = LaunchConfiguration('world')
-
-	declare_use_sim_time_cmd = DeclareLaunchArgument(
-		'use_sim_time',
-		default_value='True',
-		description='Use simulation (Gazebo) clock if true')
-
-	declare_simulator_cmd = DeclareLaunchArgument(
-		'headless',
-		default_value='False',
-		description='Whether to execute gzclient)')
-
-	declare_world_cmd = DeclareLaunchArgument(
-		'world',
-		default_value=os.path.join(aws_small_warehouse_dir, 'worlds', 'no_roof_small_warehouse', 'no_roof_small_warehouse.world'),
-		description='Full path to world model file to load')
-
-	# Specify the actions
-	start_gazebo_server_cmd = ExecuteProcess(
-		cmd=['gzserver', '--verbose', '-s', 'libgazebo_ros_init.so', '-s', 'libgazebo_ros_factory.so', world],
-		cwd=[aws_small_warehouse_dir], output='screen')
-
-	start_gazebo_client_cmd = ExecuteProcess(
-		condition=IfCondition(PythonExpression(['not ', headless])),
-		cmd=['gzclient'],
-		cwd=[aws_small_warehouse_dir], output='screen')
-
-	# Create the launch description and populate
-	ld = LaunchDescription()
-
-	# Declare the launch options
-	ld.add_action(declare_use_sim_time_cmd)
-	ld.add_action(declare_simulator_cmd)
-	ld.add_action(declare_world_cmd)
-
-	# Add any conditioned actions
-	ld.add_action(start_gazebo_server_cmd)
-	ld.add_action(start_gazebo_client_cmd)
-
-	return ld
+    ld = launch.LaunchDescription([
+        launch.actions.IncludeLaunchDescription(
+            launch.launch_description_sources.PythonLaunchDescriptionSource(
+                [get_package_share_directory(
+                    'aws_robomaker_small_warehouse_world'), '/launch/small_warehouse.launch.py']
+            ),
+            launch_arguments={
+                'world': os.path.join(get_package_share_directory('aws_robomaker_small_warehouse_world'), 'worlds', 'no_roof_small_warehouse', 'no_roof_small_warehouse.world')
+            }.items()
+        )
+    ])
+    return ld

--- a/launch/small_warehouse.launch.py
+++ b/launch/small_warehouse.launch.py
@@ -26,53 +26,53 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
-	# Get the launch directory
-	aws_small_warehouse_dir = get_package_share_directory('aws_robomaker_small_warehouse_world')
-	gazebo_ros = get_package_share_directory('gazebo_ros')
-	
-	# Launch configuration variables specific to simulation
-	use_sim_time = LaunchConfiguration('use_sim_time')
-	use_simulator = LaunchConfiguration('use_simulator')
-	headless = LaunchConfiguration('headless')
-	world = LaunchConfiguration('world')
+    # Get the launch directory
+    aws_small_warehouse_dir = get_package_share_directory('aws_robomaker_small_warehouse_world')
+    gazebo_ros = get_package_share_directory('gazebo_ros')
+    
+    # Launch configuration variables specific to simulation
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    use_simulator = LaunchConfiguration('use_simulator')
+    headless = LaunchConfiguration('headless')
+    world = LaunchConfiguration('world')
 
-	declare_use_sim_time_cmd = DeclareLaunchArgument(
-		'use_sim_time',
-		default_value='True',
-		description='Use simulation (Gazebo) clock if true')
+    declare_use_sim_time_cmd = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='True',
+        description='Use simulation (Gazebo) clock if true')
 
-	declare_simulator_cmd = DeclareLaunchArgument(
-		'headless',
-		default_value='False',
-		description='Whether to execute gzclient)')
+    declare_simulator_cmd = DeclareLaunchArgument(
+        'headless',
+        default_value='False',
+        description='Whether to execute gzclient)')
 
-	declare_world_cmd = DeclareLaunchArgument(
-		'world',
-		default_value=os.path.join(aws_small_warehouse_dir, 'worlds', 'small_warehouse', 'small_warehouse.world'),
-		description='Full path to world model file to load')
+    declare_world_cmd = DeclareLaunchArgument(
+        'world',
+        default_value=os.path.join(aws_small_warehouse_dir, 'worlds', 'small_warehouse', 'small_warehouse.world'),
+        description='Full path to world model file to load')
 
-	# Specify the actions
+    # Specify the actions
     start_gazebo_server_cmd = launch.actions.IncludeLaunchDescription(
         launch.launch_description_sources.PythonLaunchDescriptionSource(
             os.path.join(gazebo_ros, 'launch', 'gzserver.launch.py'))
     )
 
     start_gazebo_client_cmd = launch.actions.IncludeLaunchDescription(
-		launch.launch_description_sources.PythonLaunchDescriptionSource(
+        launch.launch_description_sources.PythonLaunchDescriptionSource(
             os.path.join(gazebo_ros, 'launch', 'gzclient.launch.py')),
         condition=IfCondition(PythonExpression(['not ', headless]))
     )
 
-	# Create the launch description and populate
-	ld = LaunchDescription()
+    # Create the launch description and populate
+    ld = LaunchDescription()
 
-	# Declare the launch options
-	ld.add_action(declare_use_sim_time_cmd)
-	ld.add_action(declare_simulator_cmd)
-	ld.add_action(declare_world_cmd)
+    # Declare the launch options
+    ld.add_action(declare_use_sim_time_cmd)
+    ld.add_action(declare_simulator_cmd)
+    ld.add_action(declare_world_cmd)
 
-	# Add any conditioned actions
-	ld.add_action(start_gazebo_server_cmd)
-	ld.add_action(start_gazebo_client_cmd)
+    # Add any conditioned actions
+    ld.add_action(start_gazebo_server_cmd)
+    ld.add_action(start_gazebo_client_cmd)
 
-	return ld
+    return ld

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>aws_robomaker_small_warehouse_world</name>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
   <description>
     AWS RoboMaker package for a warehouse world to use in manufacturing and logistics robot applications.
   </description>


### PR DESCRIPTION
## Description
Previously launch files execute gzserver and gzclient without gazebo_ros, which is responsible for setting up environment variables (e.g. gazebo_model_path) from the env-hooks ([reference](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/ros2/gazebo_ros/launch/gzserver.launch.py#L60))

This PR fixes that.

## Testing
**Before the changes**
Pull repo to local workspace, colcon build, source setup.sh, unset env var `GAZEBO_MODEL_PATH` and run `ros2 launch aws_robomaker_small_warehouse_world small_warehouse.launch.py` and it failed to load models and run.

**After the changes**
Pull repo to local workspace, colcon build, source setup.sh, unset env var `GAZEBO_MODEL_PATH`, source `/usr/share/gazebo/setup.sh` and run `ros2 launch aws_robomaker_small_warehouse_world small_warehouse.launch.py` and it successfully loads models and runs.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
