### PR TITLE
Fix mesh URIs to use `model://` to resolve paths

### DIFF
--- a/models/aws_robomaker_warehouse_Bucket_01/model.sdf
+++ b/models/aws_robomaker_warehouse_Bucket_01/model.sdf
@@ -21,7 +21,7 @@
       <visual name='visual'>
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_Bucket_01/meshes/aws_robomaker_warehouse_Bucket_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_Bucket_01/meshes/aws_robomaker_warehouse_Bucket_01_visual.DAE</uri>
           </mesh>
         </geometry>
 		<meta> <layer> 1 </layer></meta>
@@ -32,7 +32,7 @@
         <pose frame=''>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_Bucket_01/meshes/aws_robomaker_warehouse_Bucket_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_Bucket_01/meshes/aws_robomaker_warehouse_Bucket_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>

--- a/models/aws_robomaker_warehouse_ClutteringA_01/model.sdf
+++ b/models/aws_robomaker_warehouse_ClutteringA_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_ClutteringA_01/meshes/aws_robomaker_warehouse_ClutteringA_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_ClutteringA_01/meshes/aws_robomaker_warehouse_ClutteringA_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -44,7 +44,7 @@
       <visual name="visual">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_ClutteringA_01/meshes/aws_robomaker_warehouse_ClutteringA_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_ClutteringA_01/meshes/aws_robomaker_warehouse_ClutteringA_01_visual.DAE</uri>
           </mesh>
         </geometry>
         <meta> <layer> 1 </layer></meta>

--- a/models/aws_robomaker_warehouse_ClutteringC_01/model.sdf
+++ b/models/aws_robomaker_warehouse_ClutteringC_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_ClutteringC_01/meshes/aws_robomaker_warehouse_ClutteringC_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_ClutteringC_01/meshes/aws_robomaker_warehouse_ClutteringC_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -44,7 +44,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_ClutteringC_01/meshes/aws_robomaker_warehouse_ClutteringC_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_ClutteringC_01/meshes/aws_robomaker_warehouse_ClutteringC_01_visual.DAE</uri>
           </mesh>
         </geometry>
         <meta> <layer> 1 </layer></meta>

--- a/models/aws_robomaker_warehouse_ClutteringD_01/model.sdf
+++ b/models/aws_robomaker_warehouse_ClutteringD_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_ClutteringD_01/meshes/aws_robomaker_warehouse_ClutteringD_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_ClutteringD_01/meshes/aws_robomaker_warehouse_ClutteringD_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -44,7 +44,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_ClutteringD_01/meshes/aws_robomaker_warehouse_ClutteringD_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_ClutteringD_01/meshes/aws_robomaker_warehouse_ClutteringD_01_visual.DAE</uri>
           </mesh>
         </geometry>
       <meta> <layer> 1 </layer></meta>

--- a/models/aws_robomaker_warehouse_DeskC_01/model.sdf
+++ b/models/aws_robomaker_warehouse_DeskC_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_DeskC_01/meshes/aws_robomaker_warehouse_DeskC_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_DeskC_01/meshes/aws_robomaker_warehouse_DeskC_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -35,7 +35,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_DeskC_01/meshes/aws_robomaker_warehouse_DeskC_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_DeskC_01/meshes/aws_robomaker_warehouse_DeskC_01_visual.DAE</uri>
           </mesh>
         </geometry>
       <meta> <layer> 1 </layer></meta>

--- a/models/aws_robomaker_warehouse_GroundB_01/model.sdf
+++ b/models/aws_robomaker_warehouse_GroundB_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_GroundB_01/meshes/aws_robomaker_warehouse_GroundB_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_GroundB_01/meshes/aws_robomaker_warehouse_GroundB_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -35,7 +35,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_GroundB_01/meshes/aws_robomaker_warehouse_GroundB_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_GroundB_01/meshes/aws_robomaker_warehouse_GroundB_01_visual.DAE</uri>
           </mesh>
         </geometry>
       <meta> <layer> 1 </layer></meta>

--- a/models/aws_robomaker_warehouse_Lamp_01/model.sdf
+++ b/models/aws_robomaker_warehouse_Lamp_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_Lamp_01/meshes/aws_robomaker_warehouse_Lamp_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_Lamp_01/meshes/aws_robomaker_warehouse_Lamp_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -35,7 +35,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_Lamp_01/meshes/aws_robomaker_warehouse_Lamp_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_Lamp_01/meshes/aws_robomaker_warehouse_Lamp_01_visual.DAE</uri>
           </mesh>
         </geometry>
       <meta> <layer> 1 </layer></meta>

--- a/models/aws_robomaker_warehouse_PalletJackB_01/model.sdf
+++ b/models/aws_robomaker_warehouse_PalletJackB_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_PalletJackB_01/meshes/aws_robomaker_warehouse_PalletJackB_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_PalletJackB_01/meshes/aws_robomaker_warehouse_PalletJackB_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -35,7 +35,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_PalletJackB_01/meshes/aws_robomaker_warehouse_PalletJackB_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_PalletJackB_01/meshes/aws_robomaker_warehouse_PalletJackB_01_visual.DAE</uri>
           </mesh>
         </geometry>
       <meta> <layer> 1 </layer></meta>

--- a/models/aws_robomaker_warehouse_RoofB_01/model.sdf
+++ b/models/aws_robomaker_warehouse_RoofB_01/model.sdf
@@ -17,7 +17,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_RoofB_01/meshes/aws_robomaker_warehouse_RoofB_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_RoofB_01/meshes/aws_robomaker_warehouse_RoofB_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -45,7 +45,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_RoofB_01/meshes/aws_robomaker_warehouse_RoofB_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_RoofB_01/meshes/aws_robomaker_warehouse_RoofB_01_visual.DAE</uri>
           </mesh>
         </geometry>
       <meta> <layer> 3 </layer></meta>

--- a/models/aws_robomaker_warehouse_ShelfD_01/model.sdf
+++ b/models/aws_robomaker_warehouse_ShelfD_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_ShelfD_01/meshes/aws_robomaker_warehouse_ShelfD_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_ShelfD_01/meshes/aws_robomaker_warehouse_ShelfD_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -35,7 +35,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_ShelfD_01/meshes/aws_robomaker_warehouse_ShelfD_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_ShelfD_01/meshes/aws_robomaker_warehouse_ShelfD_01_visual.DAE</uri>
           </mesh>
         </geometry>
       <meta> <layer> 1 </layer></meta>

--- a/models/aws_robomaker_warehouse_ShelfE_01/model.sdf
+++ b/models/aws_robomaker_warehouse_ShelfE_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_ShelfE_01/meshes/aws_robomaker_warehouse_ShelfE_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_ShelfE_01/meshes/aws_robomaker_warehouse_ShelfE_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -35,7 +35,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_ShelfE_01/meshes/aws_robomaker_warehouse_ShelfE_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_ShelfE_01/meshes/aws_robomaker_warehouse_ShelfE_01_visual.DAE</uri>
           </mesh>
         </geometry>
       <meta> <layer> 1 </layer></meta>

--- a/models/aws_robomaker_warehouse_ShelfF_01/model.sdf
+++ b/models/aws_robomaker_warehouse_ShelfF_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_ShelfF_01/meshes/aws_robomaker_warehouse_ShelfF_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_ShelfF_01/meshes/aws_robomaker_warehouse_ShelfF_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -35,7 +35,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_ShelfF_01/meshes/aws_robomaker_warehouse_ShelfF_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_ShelfF_01/meshes/aws_robomaker_warehouse_ShelfF_01_visual.DAE</uri>
           </mesh>
         </geometry>
       <meta> <layer> 1 </layer></meta>

--- a/models/aws_robomaker_warehouse_TrashCanC_01/model.sdf
+++ b/models/aws_robomaker_warehouse_TrashCanC_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_TrashCanC_01/meshes/aws_robomaker_warehouse_TrashCanC_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_TrashCanC_01/meshes/aws_robomaker_warehouse_TrashCanC_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -35,7 +35,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_TrashCanC_01/meshes/aws_robomaker_warehouse_TrashCanC_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_TrashCanC_01/meshes/aws_robomaker_warehouse_TrashCanC_01_visual.DAE</uri>
           </mesh>
         </geometry>
       <meta> <layer> 1 </layer></meta>

--- a/models/aws_robomaker_warehouse_WallB_01/model.sdf
+++ b/models/aws_robomaker_warehouse_WallB_01/model.sdf
@@ -16,7 +16,7 @@
       <collision name="collision">
         <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_WallB_01/meshes/aws_robomaker_warehouse_WallB_01_collision.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_WallB_01/meshes/aws_robomaker_warehouse_WallB_01_collision.DAE</uri>
             <scale>1 1 1</scale>
           </mesh>
         </geometry>
@@ -35,7 +35,7 @@
       <visual name="visual">
 	    <geometry>
           <mesh>
-            <uri>file://models/aws_robomaker_warehouse_WallB_01/meshes/aws_robomaker_warehouse_WallB_01_visual.DAE</uri>
+            <uri>model://aws_robomaker_warehouse_WallB_01/meshes/aws_robomaker_warehouse_WallB_01_visual.DAE</uri>
           </mesh>
         </geometry>
       <meta> <layer> 2 </layer></meta>


### PR DESCRIPTION
Fix mesh URIs to use `model://` to resolve paths. Otherwise, visualisation tools such as gzweb will fail to resolve the relative path to mesh assets defined in the model's SDF file. For more examples on the `model://` URI schema:

- https://github.com/gazebosim/sdformat/issues/155#issuecomment-1490417345
- https://github.com/turtlebot/turtlebot4_simulator/blob/05e86c72e25a9922d074577e10cde765147034c1/turtlebot4_ignition_bringup/worlds/turtlebot4_world.sdf#L56
- https://github.com/ROBOTIS-GIT/turtlebot3_simulations/blob/f1b300b46decb48bd2d0767bdbf2a118b262b13c/turtlebot3_gazebo/models/turtlebot3_burger/model.sdf#L36

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.