### PR TITLE
Migrate to using the new Gazebo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(aws_robomaker_small_warehouse_world)
 # Find ament packages and libraries for ament and system dependencies
 ################################################################################
 find_package(ament_cmake REQUIRED)
-find_package(gazebo_ros REQUIRED)
+find_package(ros_gz_sim REQUIRED)
 
 ################################################################################
 # Install
@@ -21,7 +21,7 @@ install(
 ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/aws_robomaker_small_warehouse_world.dsv.in")
 
 ament_export_dependencies(ament_cmake)
-ament_export_dependencies(gazebo_ros)
+ament_export_dependencies(ros_gz_sim)
 
 ################################################################################
 # Macro for ament package

--- a/README.md
+++ b/README.md
@@ -61,9 +61,18 @@ This Gazebo world is well suited for organizations who are building and testing 
 
 To open this world in Gazebo, change the directory to your ROS workspace root folder and run:
 
+If using Gazebo Garden or later:
+
 ```bash
-export GAZEBO_MODEL_PATH=`pwd`/models
-gazebo worlds/small_warehouse/small_warehouse.world
+export GZ_SIM_RESOURCE_PATH=`pwd`/models
+gz sim worlds/small_warehouse/small_warehouse.world
+```
+
+or if using Ignition Fortress or earlier:
+
+```bash
+export IGN_SIM_RESOURCE_PATH=`pwd`/models
+ign gazebo worlds/small_warehouse/small_warehouse.world
 ```
 
 ## Example: Running this world directly using ROS without a simulated robot

--- a/env-hooks/aws_robomaker_small_warehouse_world.dsv.in
+++ b/env-hooks/aws_robomaker_small_warehouse_world.dsv.in
@@ -1,2 +1,6 @@
-prepend-non-duplicate;GAZEBO_MODEL_PATH;share/aws_robomaker_small_warehouse_world/models
-prepend-non-duplicate;GAZEBO_MODEL_PATH;share/aws_robomaker_small_warehouse_world/worlds
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/aws_robomaker_small_warehouse_world/
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/aws_robomaker_small_warehouse_world/models
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/aws_robomaker_small_warehouse_world/worlds
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;share/aws_robomaker_small_warehouse_world/
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;share/aws_robomaker_small_warehouse_world/models
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;share/aws_robomaker_small_warehouse_world/worlds

--- a/models/aws_robomaker_warehouse_GroundB_01/model.sdf
+++ b/models/aws_robomaker_warehouse_GroundB_01/model.sdf
@@ -4,14 +4,6 @@
     <link name="link">
       <inertial>
         <mass>1000</mass>
-		<inertia>
-          <ixx>1200083.33</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>8333416.66</iyy>
-          <iyz>0</iyz>
-          <izz>2033333.33</izz>
-        </inertia>
       </inertial>
       <collision name="collision">
         <geometry>

--- a/models/aws_robomaker_warehouse_RoofB_01/model.sdf
+++ b/models/aws_robomaker_warehouse_RoofB_01/model.sdf
@@ -5,14 +5,6 @@
       <inertial>
         <mass>1000</mass>
         <pose frame=''>0 0 0 0 0 0</pose>
-        <inertia>
-          <ixx>834024.533</ixx>
-          <ixy>0</ixy>
-          <ixz>0</ixz>
-          <iyy>459441.200</iyy>
-          <iyz>0</iyz>
-          <izz>1302083.333</izz>
-        </inertia>
       </inertial>
       <collision name="collision">
         <geometry>

--- a/package.xml
+++ b/package.xml
@@ -11,12 +11,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   
-  <depend>gazebo_ros</depend>
-  <exec_depend>gazebo</exec_depend>
-  <exec_depend>gazebo_plugins</exec_depend>
+  <depend>ros_gz_sim</depend>
 
   <export>
     <build_type>ament_cmake</build_type>
-    <gazebo_ros plugin_path="${prefix}/lib" gazebo_media_path="${prefix}" gazebo_model_path="${prefix}/models"/>
   </export>
 </package>


### PR DESCRIPTION
*Issue #22, if available:*
As you may know, Gazebo-classic (aka Gazebo11, see [Terminology](https://gazebosim.org/about#:~:text=Terminology)) is no longer being actively developed  and will not be available on ROS Jazzy ([REP 2000](https://www.ros.org/reps/rep-2000.html#jazzy-jalisco-may-2024-may-2029)). 

*Description of changes:*
- Use `ros_gz_sim` instead of `gazebo_ros`
- Remove invalid inertias

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
